### PR TITLE
Add suscriptions to subte updates by line.

### DIFF
--- a/commands/subte/suscribers/command.py
+++ b/commands/subte/suscribers/command.py
@@ -1,0 +1,66 @@
+from telegram.ext import run_async
+
+from commands.subte.suscribers.constants import MISSING_LINEA_MESSAGE, LINEAS, UNSUSCRIBED_MESSAGE
+from commands.subte.suscribers.db import get_suscriptors, remove_subte_suscriber
+from commands.subte.suscribers.utils import add_suscriber_to_linea
+from utils.decorators import handle_empty_arg, private_chat_only, admin_only, send_typing_action
+
+
+@send_typing_action
+@run_async
+@private_chat_only
+@handle_empty_arg(required_params=('args',), error_message=MISSING_LINEA_MESSAGE, parse_mode='markdown')
+def suscribe(bot, update, args):
+    """Suscribe to a subte line to receive updates via private message."""
+    linea = args[0]
+    if linea.upper() not in LINEAS:
+        update.message.reply_text(
+            '🚫 La linea elegida no existe. Intentá de nuevo con `/suscribe <linea_id>`',
+            parse_mode='markdown'
+        )
+        return
+
+    linea = linea.upper()
+    user = update.message.from_user
+    added = add_suscriber_to_linea(user.id, user.name, linea)
+    if added:
+        msg = f'✅ Listo. Serás notificado via chat privado de los updates de la linea {linea}'
+    else:
+        msg = f'🚫 Algo salió mal. Mejor intentá más tarde'
+
+    update.message.reply_text(msg)
+
+
+@send_typing_action
+@run_async
+@handle_empty_arg(required_params=('args',), error_message=UNSUSCRIBED_MESSAGE, parse_mode='markdown')
+def unsuscribe(bot, update, args):
+    linea = args[0]
+    if linea.upper() not in LINEAS:
+        update.message.reply_text('🚫 La linea elegida no existe.')
+        return
+
+    user = update.message.from_user
+    removed = remove_subte_suscriber(str(user.id), linea.upper())
+    if removed:
+        msg = f'✅ Listo. Tu suscripción quedó cancelada'
+    else:
+        msg = f'👻 Algo salió mal. Mejor intentá más tarde'
+
+    update.message.reply_text(msg, quote=False)
+
+
+@send_typing_action
+@run_async
+@admin_only
+def suscribers(bot, update):
+    items = get_suscriptors()
+    if items:
+        update.message.reply_text(
+            '\n'.join(
+                f"{item.user_name} | {item.linea.upper()}"
+                for item in items
+            )
+        )
+    else:
+        update.message.reply_text('📋 Aún no hay suscriptores a los subte updates')

--- a/commands/subte/suscribers/constants.py
+++ b/commands/subte/suscribers/constants.py
@@ -1,0 +1,8 @@
+LINEAS = ('A', 'B', 'C', 'D', 'E', 'H')
+MISSING_LINEA_MESSAGE = (
+    "Faltó agregar la linea a la cual querés suscribirte. Ejemplo: `/suscribe A`.\n"
+    f"Las lineas disponibles son: {', '.join(LINEAS)}"
+)
+UNSUSCRIBED_MESSAGE = (
+    "Faltó agregar la linea de la cual querés suscribirte. `/unsuscribe A`"
+)

--- a/commands/subte/suscribers/db.py
+++ b/commands/subte/suscribers/db.py
@@ -1,0 +1,40 @@
+import logging
+from commands.subte.suscribers.models import SubteSuscription, Session
+from utils.decorators import log_time
+
+logger = logging.getLogger(__name__)
+
+
+@log_time
+def add_subte_suscriber(user_id, name, linea):
+    session = Session()
+    suscription = SubteSuscription(user_id=user_id, user_name=name, linea=linea)
+    session.add(suscription)
+    session.commit()
+
+
+def remove_subte_suscriber(user_id, line):
+    session = Session()
+    suscription = session.query(SubteSuscription).filter_by(user_id=user_id, linea=line).first()
+    if suscription is None:
+        logger.info("Suscription (%s, %s) does not exist on db", user_id, line)
+        deleted = False
+    else:
+        session.delete(suscription)
+        session.commit()
+        logger.info("Suscription (%s, %s) DELETED", user_id, line)
+        deleted = True
+
+    return deleted
+
+
+@log_time
+def get_suscriptors():
+    session = Session()
+    return session.query(SubteSuscription).all()
+
+
+@log_time
+def get_suscriptors_by_line(line):
+    session = Session()
+    return session.query(SubteSuscription).filter_by(linea=line).all()

--- a/commands/subte/suscribers/models.py
+++ b/commands/subte/suscribers/models.py
@@ -1,0 +1,26 @@
+import os
+from sqlalchemy import create_engine, Column, Integer, String
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import sessionmaker
+
+Base = declarative_base()
+
+engine = create_engine(os.environ['DATABASE_URL'])
+Session = sessionmaker(bind=engine)
+
+
+class SubteSuscription(Base):
+    __tablename__ = 'subte_suscription'
+
+    id = Column(Integer, primary_key=True)
+
+    user_id = Column(String)
+    user_name = Column(String)
+    linea = Column(String(20))
+
+    def __repr__(self):
+        return "SubteSuscription(user_id='%s', name='%s', linea='%s')" % (
+            self.user_id,
+            self.name,
+            self.linea,
+        )

--- a/commands/subte/suscribers/utils.py
+++ b/commands/subte/suscribers/utils.py
@@ -1,0 +1,13 @@
+import logging
+from commands.subte.suscribers.db import add_subte_suscriber
+
+logger = logging.getLogger(__name__)
+
+
+def add_suscriber_to_linea(user_id, name, linea):
+    try:
+        add_subte_suscriber(user_id, name, linea)
+        return True
+    except Exception:
+        logger.info("Error saving subte suscriber", exc_info=True)
+        return False

--- a/commands/subte/updates/alerts.py
+++ b/commands/subte/updates/alerts.py
@@ -6,6 +6,7 @@ import re
 import requests
 
 from commands.subte.constants import DELAY_ICONS
+from commands.subte.suscribers.db import get_suscriptors_by_line
 
 logger = logging.getLogger(__name__)
 
@@ -28,6 +29,10 @@ def subte_updates_cron(bot, job):
             pretty_update = prettify_updates(status_updates)
 
         bot.send_message(chat_id='@subtescaba', text=pretty_update)
+        try:
+            notify_suscribers(bot, status_updates)
+        except Exception:
+            logger.error("Could not notify suscribers", exc_info=True)
         context['last_update'] = status_updates
     else:
         logger.info(
@@ -87,6 +92,12 @@ def _get_incident_text(alert):
         return None
 
     return spanish_desc['text']
+
+
+def notify_suscribers(bot, status_updates):
+    for linea, update in status_updates:
+        for suscription in get_suscriptors_by_line(linea):
+            bot.send_message(chat_id=suscription.user_id, text=f'{linea} | 🚇 {update}')
 
 
 def prettify_updates(updates):

--- a/main.py
+++ b/main.py
@@ -47,6 +47,7 @@ from commands.serie.constants import SERIE_REGEX
 from commands.snippets.constants import SAVE_REGEX, GET_REGEX, DELETE_REGEX
 from commands.start.command import start
 from commands.subte.command import subte
+from commands.subte.suscribers.command import suscribe, suscribers, unsuscribe
 from commands.subte.updates.alerts import subte_updates_cron
 from commands.tagger.all_tagger import tag_all, set_all_members
 from commands.yts.callback_handler import handle_callback
@@ -63,6 +64,9 @@ dispatcher = updater.dispatcher
 start_handler = CommandHandler('start', start)
 register_user = CommandHandler('register', register)
 authorize_handler = CommandHandler('authorize', authorize, pass_args=True)
+subte_suscriptions = CommandHandler('suscribe', suscribe, pass_args=True)
+subte_desuscriptions = CommandHandler('unsuscribe', unsuscribe, pass_args=True)
+subte_show_suscribers = CommandHandler('suscribers', suscribers)
 show_users_handler = CommandHandler('users', show_users)
 partido_handler = CommandHandler('partido', partido)
 dolar_handler = CommandHandler('dolar', dolar_hoy, pass_chat_data=True)
@@ -110,6 +114,9 @@ dispatcher.add_handler(show_users_handler)
 dispatcher.add_handler(authorize_handler)
 dispatcher.add_handler(partido_handler)
 dispatcher.add_handler(dolar_handler)
+dispatcher.add_handler(subte_suscriptions)
+dispatcher.add_handler(subte_desuscriptions)
+dispatcher.add_handler(subte_show_suscribers)
 dispatcher.add_handler(dolar_futuro_handler)
 dispatcher.add_handler(posiciones_handler)
 dispatcher.add_handler(subte_handler)

--- a/utils/decorators.py
+++ b/utils/decorators.py
@@ -5,6 +5,7 @@ import time
 import inspect
 from functools import wraps
 
+import telegram
 from telegram import ChatAction
 
 from commands.register.db import authorized_user
@@ -131,3 +132,22 @@ def requires_auth(func):
             )
 
     return restricted_func
+
+
+def private_chat_only(func):
+    @wraps(func)
+    def deco_func(bot, update, **kwargs):
+        chat_type = update.effective_chat.type
+        if chat_type == telegram.Chat.PRIVATE:
+            return func(bot, update, **kwargs)
+        else:
+            logger.info(f"{update.effective_message.text} can only be executed on a private conversation."
+                        f"{update.effective_user.name}")
+            update.effective_message.reply_text(
+                'El comando funciona solo en conversacion privada con @CuervoBot.\n'
+                'Clickea el username para iniciar una conversación con él',
+                parse_mode='markdown',
+                quote=False
+            )
+
+    return deco_func


### PR DESCRIPTION
A feature request by a user was that one can suscribe to a subte line and only receive updates from that line. Currently, one has to join @subtescaba to receive updates proactively, but this brings the updates for all subway lines, which sometimes is not wanted.

This PR allows users to `/suscribe` to a subway line and receive updates on private messages when an incident happens on that line.